### PR TITLE
Allow multiple games at once

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -3,7 +3,7 @@ module ApplicationCable
     identified_by :unique_id
  
     def connect
-      self.unique_id = 1 # SecureRandom.urlsafe_base64
+      self.unique_id = SecureRandom.urlsafe_base64
     end
   end
 end

--- a/app/channels/game_channel.rb
+++ b/app/channels/game_channel.rb
@@ -2,17 +2,11 @@ class GameChannel < ApplicationCable::Channel
   # Called when the consumer has successfully
   # become a subscriber to this channel.
   def subscribed
-    stream_from "games"
-    # stream_from "game_#{params[:game_id]}"
-    # or:
-    # game = Game.find_by(params[:slug])
-    # stream_for game
-    # TODO: find out what a 'room' is and whether I should use one to distinguish
-    # streams of info about different games.
-    # https://guides.rubyonrails.org/action_cable_overview.html#subscriber
-    # https://guides.rubyonrails.org/action_cable_overview.html#streams
-    # https://guides.rubyonrails.org/action_cable_overview.html#passing-parameters-to-channels
-    #
-    # HackerNoon: 'This becomes apparent when you involve the Channel’s stream_frommethod. Where the first argument is the string that will match what a later broadcast will publish too. Also, Rails and ActionCable come with a better helper method stream_forif you are working directly with model and objects. This will handle serialization of object ids.'
+    game = Game.find_by(slug: params[:slug])
+    stream_for game # Which means 'subscribe to this stream in particular'
+  end
+
+  def unsubscribed
+    stop_all_streams
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -73,7 +73,7 @@ class GamesController < ApplicationController
     rescue StandardError
       slug = ('a'..'z').to_a.sample(4).join
     end
-    slug = set_slug if slug == 'find' || Game.all.map(&:slug).include?(slug)
+    slug = set_slug if slug == 'find' || slug.include?('.') || Game.all.map(&:slug).include?(slug)
     slug
   end
 

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -10,7 +10,7 @@ class PlayersController < ApplicationController
     @player.game = @game
     @player.save
     session[:player_id] = @player.id
-    redirect_to game_path(slug: slug_param)
+    redirect_to game_path(slug: slug_param), alert: @game.players.one? ? 'Great! Now reload the page.' : nil
   end
 
   def quaff

--- a/app/javascript/channels/game_channel.js
+++ b/app/javascript/channels/game_channel.js
@@ -1,6 +1,7 @@
 import consumer from "./consumer"
- 
-consumer.subscriptions.create({ channel: "GameChannel"}, {
+
+consumer.subscriptions.create({ channel: "GameChannel", 
+                                slug: window.location.pathname.split('/').filter(word => word.length > 1)[1]}, {
   received(data) {
     if (data['event'] === 'new_player') {
       const players = document.getElementsByClassName('player');
@@ -27,7 +28,4 @@ consumer.subscriptions.create({ channel: "GameChannel"}, {
     }
   }
 })
-// TODO: find out what a 'room' is and whether I should use one to distinguish
-// streams of info about different games.
-// https://guides.rubyonrails.org/action_cable_overview.html#subscriber
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -18,7 +18,7 @@ class Game < ApplicationRecord
     started!
     players.sample.update!(arthur: true)
     players.reject(&:arthur?).sample.evil!
-    ActionCable.server.broadcast 'games', { message: 'The game started', event: 'game_started' }
+    GameChannel.broadcast_to(self, { message: 'The game started', event: 'game_started' })
   end
 
   def quorate?

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -38,12 +38,12 @@ class Player < ApplicationRecord
   end
 
   def broadcast_new_player_name
-    ActionCable.server.broadcast 'games', {
-      message: 'A new player joined',
-      event: 'new_player',
-      name: name,
-      quorate: game.quorate?
-    }
+    GameChannel.broadcast_to(game, {
+                               message: 'A new player joined',
+                               event: 'new_player',
+                               name: name,
+                               quorate: game.quorate?
+                             })
   end
 
   private
@@ -51,9 +51,8 @@ class Player < ApplicationRecord
   def broadcast_draught(cup)
     verb = ['drank', 'swigged', 'took a draught of', 'sipped', 'quaffed',
             'tasted', 'sampled', 'took a sip from', 'supped', 'drank'].sample
-    ActionCable.server.broadcast 'games',
-                                 { message: 'A cup was quaffed',
-                                   event: 'cup_quaffed',
-                                   description: "#{name} #{verb} cup #{cup.label}" }
+    GameChannel.broadcast_to(game, { message: 'A cup was quaffed',
+                                     event: 'cup_quaffed',
+                                     description: "#{name} #{verb} cup #{cup.label}" })
   end
 end

--- a/app/views/games/lobby.html.erb
+++ b/app/views/games/lobby.html.erb
@@ -1,68 +1,68 @@
-<div class="fixed-position">
-  <h1>Lobby</h1>
+<% unless flash.present? %>
+  <div class="fixed-position">
+    <h1>Lobby</h1>
+
+    <section>
+      <p>Share this URL to invite players: <a href="<%=@url%>"><%=@url%></a> </p>
+      <%= button_to 'Start (when all the players are here)', start_game_path(slug: @game.slug), disabled: (!@game.quorate? || @game.started? ), id: 'startButton' %>
+      <h2>The Players</h2>
+        <div id="players">
+        <% @game.number_of_players.times do |index| %>
+          <p class="player">
+            <%= index + 1 %>. 
+            <span id="playerName<%= index %>">
+              <% if @game.players[index] %>
+                <%= @game.players[index]&.name %>
+                <% if @game.players[index] == @player%>
+                  (you)
+                <% end %>
+              <% end %>
+            </span>
+          </p>
+        <% end %>
+        </div>
+      </p>
+    </section>
+  </div>
 
   <section>
-    <p>Share this URL to invite players: <a href="<%=@url%>"><%=@url%></a> </p>
-    <%= button_to 'Start (when all the players are here)', start_game_path(slug: @game.slug), disabled: (!@game.quorate? || @game.started? ), id: 'startButton' %>
-    <h2>The Players</h2>
-      <div id="players">
-      <% @game.number_of_players.times do |index| %>
-        <p class="player">
-          <%= index + 1 %>. 
-          <span id="playerName<%= index %>">
-            <% if @game.players[index] %>
-              <%= @game.players[index]&.name %>
-              <% if @game.players[index] == @player%>
-                (you)
-              <% end %>
-            <% end %>
-          </span>
-        </p>
-      <% end %>
-      </div>
-    </p>
+    <div class="marginnote">
+      <p><span class="drop-caps-m">M</span>y good knights,</p>
+      
+      <p>All my life, I have sought the <span class="newthought red">Holy Grail</span>, in order that all people might share in its wealth, and enjoy a supernaturally long span of healthy life.</p>
+      
+      <p>Not all you who sit here this <%=@day_or_night%> were yet born at this quest’s beginning. I still fervently believe in the cause of life, and our eventual victory over death.
+      
+      <p>But I am grown old, and the <span class="newthought">Grail</span> eludes us yet. It pains me to say this, my young friends, but I scarecly retain the sharpness of—what’s that word?—<i>mind</i>, that was it. Now, where was I...? Ah yes. I scarcely retain the sharpness of mind to rule. No, do not flatter me with contradictions. I know I am wasting away, and am not in my prime.
+      
+      <p>What, you rightly ask, prevents me from passing on the mantle to the right person?
+      
+      <% # TODO: make 'one' below responsive to the game set up. %>
+      <p>One of our number has done a great evil, who surely sits at this uncorner’d table.
+      
+      <p>They have found the <span class="newthought">Holy Grail</span>, and have taken it for themselves!
+      
+      <p>This traitor in our mydthst shall <i>never</i> wear the crown, else my name is not Arthur Pendragon.
+      
+      <p>As if unsated by this evil, it is also known that the enemy consulted with unholy powers, in order to forge a false <span class="newthought">Grail</span>, indistinguishable from the original.
+      
+      <p>Any who drink from this <span class="newthought red">Accursèd Chalice</span> will likewise lose their faith and pledge allegiancy to dark forces.
+      
+      <p>That low trick might well have confounded and ensnared us all, were it not for Merlin’s cunning. After uncovering the forgery, Merlin called upon strong magics to fashion a <i>third</i> goblet, to reverse the effect of the <span class="newthought">Accursèd Chalice</span>.
+      
+      <p>In order to ensnare and confound the enemy, <span class="newthought red">Merlin’s Goblet</span> is indistinguishable in every single aspect from the <span class="newthought">Accursèd Chalice</span>. A clever trick, as you will agree!
+      
+      <p>The enemy was not careful in all things, and covered their tracks poorly, allowing Merlin to uncover the hiding place of the <span class="newthought">Holy Grail</span> and the <span class="newthought">Accursèd Chalice</span>, which are now in our possession—though indistinguishable.
+      
+      <p>Slightly embarrassingly, the cups were dropped in transit, so we are not now sure which is <span class="newthought">Merlin’s Goblet</span>.
+      
+      <p>Never mind. All that stands between us and victory is simply to work out which cup is which, without becoming corrupted ourselves in the process. Then we may vouchsafe the health and happiness of Britain and all the world, for all time.
+      
+      <p>Of course, if you should fail, and the <span class="newthought">Accursèd Chalice</span> I do drink, it will spell disaster, doom, demise, despair—not to mention devastation. I shall be a device for dark deeds, for the delight of demons, enduring in deathless dominion.
+      
+      <p>But no pressure! Take your time!
+      
+      <p>But don’t take too long, or I might die of old age! So be quick, and get it right. No rush! Hurry, we haven’t much time!—but you must be absolutely certain, or all will be lost! So for Heaven’s sake get cracking!
+    </div>
   </section>
-</div>
-
-<section>
-  <div class="marginnote">
-    <p><span class="drop-caps-m">M</span>y good knights,</p>
-    
-    <p>All my life, I have sought the <span class="newthought red">Holy Grail</span>, in order that all people might share in its wealth, and enjoy a supernaturally long span of healthy life.</p>
-    
-    <p>Not all you who sit here this <%=@day_or_night%> were yet born at this quest’s beginning. I still fervently believe in the cause of life, and our eventual victory over death.
-    
-    <p>But I am grown old, and the <span class="newthought">Grail</span> eludes us yet. It pains me to say this, my young friends, but I scarecly retain the sharpness of—what’s that word?—<i>mind</i>, that was it. Now, where was I...? Ah yes. I scarcely retain the sharpness of mind to rule. No, do not flatter me with contradictions. I know I am wasting away, and am not in my prime.
-    
-    <p>What, you rightly ask, prevents me from passing on the mantle to the right person?
-    
-    <% # TODO: make 'one' below responsive to the game set up. %>
-    <p>One of our number has done a great evil, who surely sits at this uncorner’d table.
-    
-    <p>They have found the <span class="newthought">Holy Grail</span>, and have taken it for themselves!
-    
-    <p>This traitor in our mydthst shall <i>never</i> wear the crown, else my name is not Arthur Pendragon.
-    
-    <p>As if unsated by this evil, it is also known that the enemy consulted with unholy powers, in order to forge a false <span class="newthought">Grail</span>, indistinguishable from the original.
-    
-    <p>Any who drink from this <span class="newthought red">Accursèd Chalice</span> will likewise lose their faith and pledge allegiancy to dark forces.
-    
-    <p>That low trick might well have confounded and ensnared us all, were it not for Merlin’s cunning. After uncovering the forgery, Merlin called upon strong magics to fashion a <i>third</i> goblet, to reverse the effect of the <span class="newthought">Accursèd Chalice</span>.
-    
-    <p>In order to ensnare and confound the enemy, <span class="newthought red">Merlin’s Goblet</span> is indistinguishable in every single aspect from the <span class="newthought">Accursèd Chalice</span>. A clever trick, as you will agree!
-    
-    <p>The enemy was not careful in all things, and covered their tracks poorly, allowing Merlin to uncover the hiding place of the <span class="newthought">Holy Grail</span> and the <span class="newthought">Accursèd Chalice</span>, which are now in our possession—though indistinguishable.
-    
-    <p>Slightly embarrassingly, the cups were dropped in transit, so we are not now sure which is <span class="newthought">Merlin’s Goblet</span>.
-    
-    <p>Never mind. All that stands between us and victory is simply to work out which cup is which, without becoming corrupted ourselves in the process. Then we may vouchsafe the health and happiness of Britain and all the world, for all time.
-    
-    <p>Of course, if you should fail, and the <span class="newthought">Accursèd Chalice</span> I do drink, it will spell disaster, doom, demise, despair—not to mention devastation. I shall be a device for dark deeds, for the delight of demons, enduring in deathless dominion.
-    
-    <p>But no pressure! Take your time!
-    
-    <p>But don’t take too long, or I might die of old age! So be quick, and get it right. No rush! Hurry, we haven’t much time!—but you must be absolutely certain, or all will be lost! So for Heaven’s sake get cracking!
-  </div>
-</section>
-
-
+<% end %>

--- a/spec/features/feature_spec.rb
+++ b/spec/features/feature_spec.rb
@@ -21,6 +21,8 @@ RSpec.feature 'Gameplay' do
       # Goes to lobby because not yet quorate
       expect(current_path).to match(/#{word_api_slug}/)
       expect(game.number_of_players).to eq number_of_players
+      expect(page).to have_content('reload the page')
+      visit game_path(slug: game.slug)
       expect(page).to have_content('Lobby')
       expect(page).not_to have_content('Start') # Because we are not quorate
       expect(page).to have_content("/games/#{word_api_slug}") # Displays the url to share


### PR DESCRIPTION
There is a monkey patch going on at the moment because
for a consumer to subscribe to an ActionCable stream,
they need to perform a GET request that is not from a
post-POST redirect, it seems. So I just ask the player
in that case to reload.